### PR TITLE
Change variable from $path to $cloned to fix ZSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ In order for the example above to work, you'll need to configure a bash function
 
 ```
 cl() {
-  path=$(command cl -dir "$GOPATH/src" "$1")
-  cd "$path"
+  cloned=$(command cl -dir "$GOPATH/src" "$1")
+  cd "$cloned"
 }
 ```
 


### PR DESCRIPTION
Setting `path` broke my ZSH 😬